### PR TITLE
Update sdk and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.10.2
+FROM circleci/golang:1.10
 
 ENV APPENGINE_VERSION=1.9.67
 ENV HOME=/home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM circleci/golang:1.10
 
-ENV APPENGINE_VERSION=1.9.67
+ENV APPENGINE_VERSION=1.9.68
 ENV HOME=/home/circleci
 ENV SDK=https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${APPENGINE_VERSION}.zip \
     PATH=${HOME}/go_appengine:${PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-FROM circleci/golang:1.10
+FROM circleci/golang:1.10-node
 
 ENV APPENGINE_VERSION=1.9.68
 ENV HOME=/home/circleci
 ENV SDK=https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${APPENGINE_VERSION}.zip \
     PATH=${HOME}/go_appengine:${PATH}
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 RUN sudo apt-get update && sudo apt-get install -y \
     musl-dev \
-    nodejs \
     python-pygments \
     && sudo apt-get clean \
     && sudo rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN curl -sL -O https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSI
 
 # Install util
 RUN sudo npm install -g yarn \
-    && go get -u gopkg.in/alecthomas/gometalinter.v2 \
-    && ln -s $GOPATH/bin/gometalinter.v2 $GOPATH/bin/gometalinter \
-    && gometalinter --install \
-    && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
+    && curl https://raw.githubusercontent.com/alecthomas/gometalinter/master/scripts/install.sh | sudo -E sh
 #RUN goapp get github.com/jstemmer/go-junit-report


### PR DESCRIPTION
* Use [circleci/golang:1.10-node](https://hub.docker.com/r/circleci/golang/) instead of [circleci/golang:1.10.2](https://hub.docker.com/r/circleci/golang/)
    * Includes node 8.x
* Update dependencies
  * [GAE/Go SDK 1.9.68](https://cloud.google.com/appengine/docs/standard/go/release-notes#september_12_2018)

---

package versions (docker-gae-go:1.9.67)
```
$ cat /etc/debian_version
9.4
$ node --version
v8.11.3
$ npm --version
5.6.0
$ yarn --version
1.7.0
$ hugo version
Hugo Static Site Generator v0.30.2 linux/amd64 BuildDate: 2017-10-19T11:34:27Z
$ go version
go version go1.10.2 linux/amd64
$ goapp version
go version 1.9.4 (appengine-1.9.74) linux/amd64
$ gometalinter --version
gometalinter version master built from ? on
$ dep version
dep:
 version     : v0.4.1
 build date  : 2018-01-24
 git hash    : 37d9ea0a
 go version  : go1.9.1
 go compiler : gc
 platform    : linux/amd64
```

package versions (docker-gae-go:1.9.68)
```
$ cat /etc/debian_version
9.5
$ node --version
v8.12.0
$ npm --version
6.4.1
$ yarn --version
1.10.1
$ hugo version
Hugo Static Site Generator v0.30.2 linux/amd64 BuildDate: 2017-10-19T11:34:27Z
$ go version
go version go1.10.4 linux/amd64
$ goapp version
go version 1.9.4 (appengine-1.9.75) linux/amd64
$ gometalinter --version
gometalinter version 2.0.11 built from 17a7ffa42374937bfecabfb8d2efbd4db0c26741 on 2018-09-09T06:19:21Z
$ dep version
dep:
 version     : v0.5.0
 build date  : 2018-07-26
 git hash    : 224a564
 go version  : go1.10.3
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
```
